### PR TITLE
Import stuff from base instead of mtl

### DIFF
--- a/src/Advent.hs
+++ b/src/Advent.hs
@@ -82,7 +82,9 @@ import           Advent.Throttle
 import           Advent.Types
 import           Control.Concurrent.STM
 import           Control.Exception
+import           Control.Monad
 import           Control.Monad.Except
+import           Control.Monad.IO.Class
 import           Data.Kind
 import           Data.Map                (Map)
 import           Data.Maybe


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `advent-of-code-api` in line with the proposed change, because at the moment `Advent` exports `guard`, `when`, `forM_`, `(<=<)` (originally from `Control.Monad`) and `liftIO` (originally from `Control.Monad.IO.Class`) from `Control.Monad.Except`.