### PR TITLE
Add stats endpoint parsing

### DIFF
--- a/advent-of-code-api.cabal
+++ b/advent-of-code-api.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           advent-of-code-api
-version:        0.2.10.0
+version:        0.2.11.0
 synopsis:       Advent of Code REST API bindings and servant API
 description:    Haskell bindings for Advent of Code REST API and a servant API.  Please use
                 responsibly! See README.md or "Advent" module for an introduction and

--- a/src/Advent.hs
+++ b/src/Advent.hs
@@ -250,7 +250,7 @@ data AoC :: Type -> Type where
     --
     -- /Cacheing rules/: Not cached.
     --
-    -- @since 0.2.9.0
+    -- @since 0.2.11.0
     AoCStats
         :: AoC Stats
 

--- a/src/Advent/API.hs
+++ b/src/Advent/API.hs
@@ -313,9 +313,9 @@ parseStatLine (TagBranch _ _ cs) = do
     pure (dy, DayStats gold silver)
   where
     findNum cls = listToMaybe . mapMaybe (go cls)
-    go cls (TagBranch "span" attr inner)
-      | ("class", cls) `elem` attr
-      , Just n <- readMaybe . T.unpack . T.strip $ innerText inner = Just n
+    go cls (TagBranch "span" attr inner) = do
+      guard $ ("class", cls) `elem` attr
+      readMaybe . T.unpack . T.strip $ innerText inner
     go _ _ = Nothing
 parseStatLine _ = Nothing
 

--- a/src/Advent/API.hs
+++ b/src/Advent/API.hs
@@ -113,6 +113,9 @@ type Divs     = HTMLTags "div"
 -- | Interpret a response as a list of HTML 'T.Text' found in @<script>@ tags.
 type Scripts = HTMLTags "script"
 
+-- | Interpret a response as a list of HTML 'T.Text' found in @<pre>@ tags.
+type Pres = HTMLTags "pre"
+
 -- | Class for interpreting a list of 'T.Text' in tags to some desired
 -- output.
 --
@@ -250,7 +253,7 @@ type AdventAPI =
       Header "User-Agent" AoCUserAgent
    :> Capture "year" Integer
    :> (Get '[Scripts] NextDayTime
-  :<|> "stats" :> Get '[HTMLTags "pre"] Stats
+  :<|> "stats" :> Get '[Pres] Stats
   :<|> "day" :> Capture "day" Day
              :> (Get '[Articles] (Map Part Text)
             :<|> "input" :> Get '[RawText] Text
@@ -305,9 +308,9 @@ parseStatLine :: TagTree Text -> Maybe (Day, DayStats)
 parseStatLine (TagBranch _ _ cs) = do
     dayTxt <- listToMaybe [t | TagLeaf (H.TagText t) <- cs, not (T.null (T.strip t))]
     dy     <- mkDay =<< readMaybe (T.unpack (T.strip dayTxt))
-    both   <- findNum "stats-both" cs
-    first  <- findNum "stats-firstonly" cs
-    pure (dy, DayStats (fromIntegral both) (fromIntegral first))
+    gold   <- findNum "stats-both" cs
+    silver <- findNum "stats-firstonly" cs
+    pure (dy, DayStats gold silver)
   where
     findNum cls = listToMaybe . mapMaybe (go cls)
     go cls (TagBranch "span" attr inner)

--- a/src/Advent/API.hs
+++ b/src/Advent/API.hs
@@ -299,10 +299,10 @@ adventAPIPuzzleClient aua y = pis
     _ :<|> _ :<|> pis :<|> _ = adventAPIClient aua y
 
 parseStats :: Text -> Maybe Stats
-parseStats = fmap M.fromList . traverse parseStatLine . mapMaybe asBranch . H.parseTree
+parseStats = fmap M.fromList . traverse parseStatLine . filter asBranch . H.parseTree
   where
-    asBranch b@TagBranch{} = Just b
-    asBranch _             = Nothing
+    asBranch TagBranch{} = True
+    asBranch _           = False
 
 parseStatLine :: TagTree Text -> Maybe (Day, DayStats)
 parseStatLine (TagBranch _ _ cs) = do

--- a/src/Advent/Types.hs
+++ b/src/Advent/Types.hs
@@ -266,8 +266,8 @@ data NextDayTime = NextDayTime Day Int
 --
 -- @since 0.2.9.0
 data DayStats = DayStats
-    { dsBoth      :: Integer   -- ^ Users who completed both parts
-    , dsFirstOnly :: Integer   -- ^ Users who only completed the first part
+    { dsGold   :: Integer   -- ^ Users who completed both parts
+    , dsSilver :: Integer   -- ^ Users who only completed the first part
     }
   deriving (Show, Read, Eq, Ord, Typeable, Generic)
 

--- a/src/Advent/Types.hs
+++ b/src/Advent/Types.hs
@@ -264,7 +264,7 @@ data NextDayTime = NextDayTime Day Int
 
 -- | Stats for a single day on the event stats page.
 --
--- @since 0.2.9.0
+-- @since 0.2.11.0
 data DayStats = DayStats
     { dsGold   :: Integer   -- ^ Users who completed both parts
     , dsSilver :: Integer   -- ^ Users who only completed the first part
@@ -273,7 +273,7 @@ data DayStats = DayStats
 
 -- | Stats for all days on the event stats page.
 --
--- @since 0.2.9.0
+-- @since 0.2.11.0
 type Stats = Map Day DayStats
 
 instance ToHttpApiData Part where

--- a/src/Advent/Types.hs
+++ b/src/Advent/Types.hs
@@ -43,6 +43,8 @@ module Advent.Types (
   , GlobalLeaderboard(..)
   , GlobalLeaderboardMember(..)
   , NextDayTime(..)
+  , DayStats(..)
+  , Stats
   -- * Util
   , mkDay, mkDay_, dayInt
   , _DayInt, pattern DayInt
@@ -259,6 +261,20 @@ newtype GlobalLeaderboard = GLB {
 data NextDayTime = NextDayTime Day Int
                  | NoNextDayTime
   deriving (Show, Eq, Ord, Typeable, Generic)
+
+-- | Stats for a single day on the event stats page.
+--
+-- @since 0.2.9.0
+data DayStats = DayStats
+    { dsBoth      :: Integer   -- ^ Users who completed both parts
+    , dsFirstOnly :: Integer   -- ^ Users who only completed the first part
+    }
+  deriving (Show, Read, Eq, Ord, Typeable, Generic)
+
+-- | Stats for all days on the event stats page.
+--
+-- @since 0.2.9.0
+type Stats = Map Day DayStats
 
 instance ToHttpApiData Part where
     toUrlPiece = T.pack . show . partInt


### PR DESCRIPTION
## Summary
- add types to represent per-day completion stats
- extend the Servant API/client with a /<year>/stats endpoint and HTML parser
- expose a new AoCStats command to fetch per-day star counts

## Testing
- Not run (stack executable not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932603b13f4832ea0a7ec026bd4cf83)