### PR TITLE
Refine stats helper and submit inference variants

### DIFF
--- a/src/Advent.hs
+++ b/src/Advent.hs
@@ -453,14 +453,14 @@ inferSubmitRes
     -> Part
     -> SubmitRes
     -> IO (Either AoCError SubmitRes)
-inferSubmitRes _ _ _ sr@(SubCorrect (Just _)) = pure $ Right sr
-inferSubmitRes opts d p (SubCorrect Nothing) = do
-    stats <- runAoC opts AoCStats
-    pure $ stats >>= \st ->
-      case M.lookup d st of
-        Just _  -> Right . SubCorrect . Just $ statsForDayPart d p st
-        Nothing -> Right $ SubCorrect Nothing
-inferSubmitRes _ _ _ sr = pure $ Right sr
+inferSubmitRes opts d p sr = case sr of
+    SubCorrect Nothing -> do
+        stats <- runAoC opts AoCStats
+        pure $ stats >>= \st ->
+          case M.lookup d st of
+            Just _  -> Right . SubCorrect . Just $ statsForDayPart d p st
+            Nothing -> Right $ SubCorrect Nothing
+    _ -> pure $ Right sr
 
 -- | Variant of 'inferSubmitRes' that returns the original response if stats
 -- lookup fails.


### PR DESCRIPTION
## Summary
- expand `statsForDayPart` to work from full stats with a day context
- adjust `inferSubmitRes` to return detailed errors and add forgiving `inferSubmitRes_`

## Testing
- not run (not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328e5aacdc832e95eea1a59df4a884)